### PR TITLE
allow npm package to work in nodejs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val root = (project in file(".")).settings(
   name := "openlaw-core-client",
   scalaVersion := scalaV,
   libraryDependencies ++= Seq(
-    "org.openlaw"              %%% "openlaw-core"              % "0.1.1"
+    "org.openlaw"              %%% "openlaw-core"              % "0.1.3"
   ),
   relativeSourceMaps := true,
   artifactPath in (Compile, fullOptJS) := crossTarget.value / "client.js",

--- a/js/src/APIClient.js
+++ b/js/src/APIClient.js
@@ -389,7 +389,7 @@ class APIClient {
     return this.getCall('/user/getStripeAccounts').then(response => response.data);
   }
 
-  getCommunityActivity(
+  async getCommunityActivity(
     filter: string,
     page: number,
     pageSize: number,

--- a/npm.README.md
+++ b/npm.README.md
@@ -36,9 +36,10 @@ user with a StandardUser role or an Admin role. Log in before making
 those calls.
 */
 apiClient.login('openlawuser+1@gmail.com', 'password');
-const templateDetails = apiClient.getTemplate('Advisor Agreement');
 
-console.log(templateDetails);
+apiClient.getTemplate('Advisor Agreement').then(result => {
+  console.log(result);
+});
 /*
 {
   "id": "d76ede8ca437f6da06b1e09f115393318faf29fdc5bdaaf0b2e889886136edf4",

--- a/openlaw.webpack.config.js
+++ b/openlaw.webpack.config.js
@@ -8,6 +8,6 @@ module.exports = {
     filename: '[name].bundle.js',
     path: path.resolve(__dirname, 'build'),
     libraryTarget: 'umd',
-    globalObject: "(typeof window !== 'undefined' ? window : this)"
+    globalObject: '(typeof window !== \'undefined\' ? window : this)'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openlaw",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlaw",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "JavaScript library for integrating the OpenLaw protocol to store, edit, and manage smart legal agreements.",
   "keywords": [
     "openlaw",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
@@ -13,8 +14,17 @@ module.exports = {
     filename: '[name].js',
     path: path.resolve(__dirname, 'build'),
     libraryTarget: 'umd',
-    globalObject: "(typeof window !== 'undefined' ? window : this)"
+    globalObject: '(typeof window !== \'undefined\' ? window : this)'
   },
+  target: 'node',
+  node: {
+    process: false
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+    })
+  ],
   module: {
     rules: [
       {


### PR DESCRIPTION
pieced together more info of how axios works with webpack, node, and web from several sources including these:
https://github.com/axios/axios/issues/456
https://lmiller1990.github.io/electic/posts/server_side_hydration_with_vue_and_webpack.html

Tested local package with nodejs and react dummy projects and openlaw-backend and all seem to be working fine. Changes in this pr also include some cleanup.

If this looks good and merged into master, I can patch update to 0.1.4 and publish again. 