### PR TITLE
WIP update core dependency to 0.1.23

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val root = (project in file(".")).settings(
   name := "openlaw-core-client",
   scalaVersion := scalaV,
   libraryDependencies ++= Seq(
-    "org.openlaw"              %%% "openlaw-core"              % "0.1.22"
+    "org.openlaw"              %%% "openlaw-core"              % "0.1.23"
   ),
   relativeSourceMaps := true,
   artifactPath in (Compile, fullOptJS) := crossTarget.value / "client.js",


### PR DESCRIPTION
There is compilation error when trying to build `client.js` with the latest core dependency:

```
[info] Compiling 1 Scala source to /Users/jd/openlaw/openlawteam/openlaw-client/target/scala-2.12/classes ...
[error] /Users/jd/openlaw/openlawteam/openlaw-client/src/main/scala/org/adridadou/openlaw/client/Openlaw.scala:322:27: value getMessage is not a member of org.adridadou.openlaw.result.FailureCause
[error]           logger.error(ex.getMessage, ex)
[error]                           ^
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
[error] Total time: 15 s, completed Mar 18, 2019, 9:29:44 AM
```