### PR TITLE
custom entrypoint script to avoid CI overrides

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -62,7 +62,7 @@ workflow "Publish to NPM on release" {
 
 action "Publish" {
   uses = "docker://openlaw/client:packager"
-  runs = "./scripts/release.sh"
+  args = ["./scripts/release.sh"]
   secrets = ["NPM_TOKEN"]
   env = {
     LIVE = "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,3 +28,4 @@ RUN npm run build_prod
 # The scripts folder now contains any shell scripts designed to be run inside
 # the container itself.
 COPY scripts scripts
+ENTRYPOINT ["./scripts/entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -l
+# This is a simple entrypoint script that runs shell commands relative to the
+# container's designated WORKDIR and prevents either it or the HOME variable
+# from being overridden.
+
+# Some environments (GitHub Actions) like to override $HOME, which makes sense
+# for most actions, but not for us here, since SBT likes to install things in
+# dotfile hidden dirs there :(
+export HOME=/root
+
+# Change to our preferred workdir, in case we running in an environment that has
+# overridden it (e.g. GitHub Actions again, Google Cloud Builder)
+cd /src || exit 1
+
+# Now simply run our commands
+sh -c "$*"


### PR DESCRIPTION
Quick script that should fix the CI error on release seen in https://github.com/openlawteam/openlaw-client/runs/114468168, which was caused by Github Actions overriding the default WORKDIR during their wrapper docker run (in a way that actually makes sense for most use cases, but for us causes the layer cached `node_modules` directory to not be seen since we're now in the wrong project directory).

In addition, this should also help guard against potential Scala caching issues stemming from `$HOME` being overridden, in other usages in the future.