### PR TITLE
Semantic Version prerelease-aware script for `npm publish`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7902,6 +7902,15 @@
         }
       }
     },
+    "npm-publish-prerelease": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/npm-publish-prerelease/-/npm-publish-prerelease-1.0.2.tgz",
+      "integrity": "sha1-OQ1dsxzDZ6K9I/8wHxiyQrNbgUc=",
+      "dev": true,
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
     "npm-run-all": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "style": "prettier '{js/src/**/*.js,docs/*.md,*.md}' --check",
     "style:fix": "prettier '{js/src/**/*.js,docs/*.md,*.md}' --write",
     "prepublishOnly": "npm run build_prod",
+    "publish-semver": "npm-publish-prerelease",
     "release": "np",
     "release:patch": "np patch"
   },
@@ -97,6 +98,7 @@
     "flow-bin": "^0.87.0",
     "flow-watch": "^1.1.4",
     "np": "^5.0.1",
+    "npm-publish-prerelease": "^1.0.2",
     "npm-run-all": "^4.1.5",
     "npm-watch": "^0.4.0",
     "prettier": "1.17.0",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,11 +25,16 @@ fi
 # no longer modify the working directory.
 LIVE=${LIVE:-0}
 if [ "$LIVE" -eq "1" ]; then
-    # TODO: see if we can detect semver pre-release version strings and
-    # automatically append --tag next
+    # We can use a release script that detects semver pre-release SemVer version
+    # strings and automatically append `--tag prerelease` to the npm publish
+    # commands when they are detected. This restores proper behavior whereby end
+    # users will not automatically get a prerelease version on install unless
+    # explicitly requested.
     #
-    # See: https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420
-    npm publish --unsafe-perm=true
+    # The origin of this issue stems from NPM now starting to use their own "dist
+    # tags" that must be explicitly set, whereby they used to respect SemVer
+    # directly. See: https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420
+    npm run-script publish-semver -- --unsafe-perm=true
 else
-    npm publish --unsafe-perm=true --dry-run
+    npm run-script publish-semver -- --unsafe-perm=true --dry-run
 fi


### PR DESCRIPTION
The intros a release script that detects semver pre-release SemVer version strings and automatically append `--tag prerelease` to the npm publish commands when they are detected. This should restore proper behavior whereby end users will not automatically get a prerelease version on install unless explicitly requested, which will give us the option to push prerelease builds (for example, like when testing our build process recently) with more controlled impact on end users.

The origin of this issue stems from NPM now starting to use their own "dist tags" that must be explicitly set, when they used to respect SemVer directly. 😞 

See: https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420

### Third party code:
I briefly skimmed the source code of the newly added npm package that handles this and checked licensing, however I did not fully audit it.

### Test Plan:

1) I ran `npm run-script publish-semver -- --dry-run` locally (a close approximation of the final step of `scripts/release.sh`, verified that prepublish build steps still ran, and saw the dry-run output was still producing the proper files. _However, the dry-run output unfortunately does not indicated what tags would be used during actual upload._

2) I locally ran
```
docker build -t openlaw/client:packager .
docker run --rm -it \
    --env NPM_TOKEN=abcdefg \
    --env LIVE=0 \
    openlaw/client:packager \
    "./scripts/release.sh"
```
And saw the same output as in step 1 (again, without being able to confirm what tags will be appended on actual upload, so this just verifies that the build probably isn't broken.).


I can't think of a really good way to *really* test this though beyond merging and doing yet another test pre-release. Let me know if you have any wiser ideas.