### PR TITLE
Execute template with external call structures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val root = (project in file(".")).settings(
   name := "openlaw-core-client",
   scalaVersion := scalaV,
   libraryDependencies ++= Seq(
-    "org.openlaw"              %%% "openlaw-core"              % "0.1.39"
+    "org.openlaw"              %%% "openlaw-core"              % "0.1.40"
   ),
   relativeSourceMaps := true,
   artifactPath in (Compile, fullOptJS) := crossTarget.value / "client.js",


### PR DESCRIPTION
It adds the `externalCallStructures` to the `execute` function, so the VM can evaluate templates with  `ExternalCallType` variables. 
The `externalCallStructures` provides the ABIs of each integrated service in Openlaw App.

The PRs relies on a new release of openlaw-core with: https://github.com/openlawteam/openlaw-core/pull/140