### PR TITLE
External signature integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val root = (project in file(".")).settings(
   name := "openlaw-core-client",
   scalaVersion := scalaV,
   libraryDependencies ++= Seq(
-    "org.openlaw"              %%% "openlaw-core"              % "0.1.42"
+    "org.openlaw"              %%% "openlaw-core"              % "0.1.43"
   ),
   relativeSourceMaps := true,
   artifactPath in (Compile, fullOptJS) := crossTarget.value / "client.js",

--- a/src/main/scala/org/adridadou/openlaw/client/Openlaw.scala
+++ b/src/main/scala/org/adridadou/openlaw/client/Openlaw.scala
@@ -399,7 +399,7 @@ object Openlaw extends LazyLogging {
   @JSExport
   def getIdentities(validationResult: ValidationResult, executionResult: TemplateExecutionResult):js.Array[VariableDefinition] = {
     executionResult
-      .getVariables(IdentityType)
+      .getVariables(IdentityType, ExternalSignatureType)
       .map({case (_,variable) => variable.name -> variable})
       .toMap.values
       .filter(variable => validationResult.missingIdentities.contains(variable.name))
@@ -407,10 +407,16 @@ object Openlaw extends LazyLogging {
   }
 
   @JSExport
-  def isSignatory(email:String, executionResult: TemplateExecutionResult):Boolean = executionResult
-    .getVariableValues[Identity](IdentityType)
-    .getOrThrow()
-    .exists(_.email.email === email)
+  def isSignatory(email:String, executionResult: TemplateExecutionResult):Boolean = {
+    executionResult
+      .getVariableValues[Identity](IdentityType)
+      .getOrThrow()
+      .exists(_.email.email === email) ||
+      executionResult
+        .getVariableValues[ExternalSignature](ExternalSignatureType)
+        .getOrThrow()
+        .exists(_.identity.exists(id => id.email.email === email))
+  }
 
   @JSExport
   def getSections(document:TemplateExecutionResult):js.Array[String] = document.variableSectionList.toJSArray

--- a/src/main/scala/org/adridadou/openlaw/client/Openlaw.scala
+++ b/src/main/scala/org/adridadou/openlaw/client/Openlaw.scala
@@ -383,6 +383,10 @@ object Openlaw extends LazyLogging {
     }).toJSArray
 
   @JSExport
+  def createExternalSignatureValue(userId:js.UndefOr[String], email: String, serviceName: String):String =
+    ExternalSignatureType.internalFormat(ExternalSignature(Option(createIdentity(userId, email)), ServiceName(serviceName))).getOrThrow()
+
+  @JSExport
   def getIdentityEmail(identity:Identity):String = identity.email.email
 
   @JSExport


### PR DESCRIPTION
This PR adds a new function to Openlaw.scala that allows the client to generate the json value of a ExternalSignature type based on the input parameters.
It also changes the get the Identity and check the signatories, given that ExternaSignature is an Identity type, we need to consider that in these 2 functions as well.

Dependencies:
1. https://github.com/openlawteam/openlaw-core/pull/165