### PR TITLE
Outputs the error message as a string on compileTemplate error

### DIFF
--- a/src/main/scala/org/adridadou/openlaw/client/Openlaw.scala
+++ b/src/main/scala/org/adridadou/openlaw/client/Openlaw.scala
@@ -37,7 +37,7 @@ object Openlaw extends LazyLogging {
   def compileTemplate(text:String) : js.Dictionary[Any] = markdown.compileTemplate(text, clock) match {
     case Left(err) => js.Dictionary(
       "isError" -> true,
-      "errorMessage" -> err,
+      "errorMessage" -> err.message,
       "compiledTemplate" -> js.undefined
     )
     case Right(result) => js.Dictionary(


### PR DESCRIPTION
One line change to access `message` property of the error. Helps us on the front-end. Tested locally by pulling into app.

**From semi-unusable:**

```
{ isError: true,
  errorMessage:
       $c_Lorg_adridadou_openlaw_result_FailureMessage {
         'message$1':
          'Unexpected end of input, expected keyChar, variableTypeDefinition, ws, \'|\', stringDefinition, \' \', \']\' or \'.\' (line 1, column 15):\n[[Company Name\n              ^',
         'idOpt$1': $c_s_None$ {},
         'e$1':
          $c_jl_RuntimeException {
            's$1':
             'Unexpected end of input, expected keyChar, variableTypeDefinition, ws, \'|\', stringDefinition, \' \', \']\' or \'.\' (line 1, column 15):\n[[Company Name\n              ^',
            'e$1': null,
            'enableSuppression$1': true,
            'writableStackTrace$1': true,
            'stackTrace$1': null,
            'suppressed$1': null,
            stackdata: [Circular] },
         'id$1':
          'Unexpected end of input, expected keyChar, variableTypeDefinition, ws, \'|\', stringDefinition, \' \', \']\' or \'.\' (line 1, column 15):\n[[Company Name\n              ^' },
  compiledTemplate: undefined }
```

**To usable:**

```
{ isError: true,
  errorMessage:
       'Unexpected end of input, expected keyChar, variableTypeDefinition, ws, \'|\', stringDefinition, \' \', \']\' or \'.\' (line 1, column 15):\n[[Company Name\n              ^',
  compiledTemplate: undefined }
```