### PR TITLE
update shellcheck action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Shellcheck Lint
-        uses: actions/bin/shellcheck@master
+        uses: reviewdog/action-shellcheck@v1
         with:
-          args: scripts/*.sh ci/*.sh
+          github_token: ${{ secrets.github_token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Shellcheck Lint
-        uses: reviewdog/action-shellcheck@v1
-        with:
-          github_token: ${{ secrets.github_token }}
+        uses: azohra/shell-linter@v0.1.0


### PR DESCRIPTION
Replaces shellcheck action in deprecated GitHub `actions/bin` with https://github.com/reviewdog/action-shellcheck.

See more info on how [GitHub automatically creates a `GITHUB_TOKEN` secret to use in your workflow](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions#github_token-secret). For the other inputs, including `path` and `pattern`, looks like the defaults are sufficient to cover the current `.sh` files, but let me know if you think we need to adjust.