### PR TITLE
bump openlaw-core to 0.1.49

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val root = (project in file(".")).settings(
   name := "openlaw-core-client",
   scalaVersion := scalaV,
   libraryDependencies ++= Seq(
-    "org.openlaw"              %%% "openlaw-core"              % "0.1.47"
+    "org.openlaw"              %%% "openlaw-core"              % "0.1.49"
   ),
   relativeSourceMaps := true,
   artifactPath in (Compile, fullOptJS) := crossTarget.value / "client.js",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
 resolvers += Resolver.url("sbt-plugins", url("https://dl.bintray.com/ssidorenko/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")
 
 /* WartRemover currently chokes on ScalaJS and causes lots of false positives.


### PR DESCRIPTION
Also requires `sbt-scalajs` to be updated to v0.6.31 to match same update made in openlawteam/openlaw-core#198.