### PR TITLE
openlaw-core 0.1.51

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ project/project
 # Metals specific (Scala language server https://scalameta.org/metals/)
 .metals/
 .bloop/
+project/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val root = (project in file(".")).settings(
   name := "openlaw-core-client",
   scalaVersion := scalaV,
   libraryDependencies ++= Seq(
-    "org.openlaw"              %%% "openlaw-core"              % "0.1.50"
+    "org.openlaw"              %%% "openlaw-core"              % "0.1.51"
   ),
   relativeSourceMaps := true,
   artifactPath in (Compile, fullOptJS) := crossTarget.value / "client.js",


### PR DESCRIPTION
- Bump openlaw-core dependency to latest `0.1.51`.
- Update `.gitignore` with one more file related to Metals Scala language server tool for Visual Studio Code (https://scalameta.org/metals/docs/editors/vscode.html#gitignore-projectmetalssbt-metals-and-bloop)
