### PR TITLE
openlaw-core 0.1.52

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val root = (project in file(".")).settings(
   name := "openlaw-core-client",
   scalaVersion := scalaV,
   libraryDependencies ++= Seq(
-    "org.openlaw"              %%% "openlaw-core"              % "0.1.51"
+    "org.openlaw"              %%% "openlaw-core"              % "0.1.52"
   ),
   relativeSourceMaps := true,
   artifactPath in (Compile, fullOptJS) := crossTarget.value / "client.js",


### PR DESCRIPTION
Bumps openlaw-core dependency to latest 0.1.52.

`client.js` generates fine and the build completes with no errors after the core bump.