### PR TITLE
bump openlaw-core to 0.1.58

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val root = (project in file("."))
     name := "openlaw-core-client",
     scalaVersion := scalaV,
     libraryDependencies ++= Seq(
-      "org.openlaw" %%% "openlaw-core" % "0.1.57"
+      "org.openlaw" %%% "openlaw-core" % "0.1.58"
     ),
     relativeSourceMaps := true,
     artifactPath in (Compile, fullOptJS) := crossTarget.value / "client.js",


### PR DESCRIPTION
- bumps openlaw-core to 0.1.58 (no compile issues in generating `client.js`)
