### PR TITLE
remove deprecated disableFlowAccessToken call

### DIFF
--- a/js/src/APIClient.js
+++ b/js/src/APIClient.js
@@ -240,12 +240,6 @@ export class APIClient {
     );
   }
 
-  async disableFlowAccessToken(flowId: string): Promise<string> {
-    return this.postCall('/flow/disableToken/' + flowId).then(
-      response => response.data,
-    );
-  }
-
   async signContract(
     contractId: string,
     fullName: string,


### PR DESCRIPTION
Route and endpoint for the `disableFlowAccessToken` call were removed from openlaw-app as part of the Flow access updates.