### PR TITLE
bump openlaw-core 0.1.63

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val root = (project in file("."))
     name := "openlaw-core-client",
     scalaVersion := scalaV,
     libraryDependencies ++= Seq(
-      "org.openlaw" %%% "openlaw-core" % "0.1.62"
+      "org.openlaw" %%% "openlaw-core" % "0.1.63"
     ),
     relativeSourceMaps := true,
     artifactPath in (Compile, fullOptJS) := crossTarget.value / "client.js",


### PR DESCRIPTION
Bumps openlaw-core to latest release version.