### PR TITLE
build(ci): replace third-party shellcheck action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,23 +8,24 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "10.x"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: npm ci
       - run: npm run lint
       - run: npm run style
 
   lint-shell:
-    runs-on: ubuntu-latest
+    name: Run shellcheck
+    runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
-      - name: Shellcheck Lint
-        uses: azohra/shell-linter@v0.1.0
+      - uses: actions/checkout@v2
+      - name: shellcheck
+        run: shellcheck
 
   lint-scala:
     name: Run scalafmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - uses: openlawteam/scalafmt-ci@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: shellcheck
-        run: shellcheck
+        run: shellcheck ci/*.sh scripts/*.sh
 
   lint-scala:
     name: Run scalafmt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,7 @@ name: Linters on push
 
 jobs:
   lint-js:
+    name: Run JS lints
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v1


### PR DESCRIPTION
shellcheck is preinstalled on current version of GHA virtual env, so just run it directly instead of using an action at all.

The environment version in this sub-job is pinned since it now relies on something being present in the environment's preinstalled software, as a safety hedge just in case this is removed as preinstalled software when latest of ubuntu for GHA changes in ~2 years.

(conforming change with openlawteam/openlaw-app#3140)